### PR TITLE
Allow generator.py to run with Python3

### DIFF
--- a/data/generator.py
+++ b/data/generator.py
@@ -8,7 +8,7 @@ import argparse
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(description="generates 100000 rows of sample records, or a given count of record if -c flag is specified")
+    parser = argparse.ArgumentParser(description="generates 1000000 rows of sample records, or a given count of record if -c flag is specified")
     parser.add_argument("-c","--count", help="count of records to be generated",type=int)
     args = parser.parse_args()
 
@@ -18,21 +18,20 @@ if __name__ == "__main__":
         total_record = 1000000
 
     np.random.seed(0)
-    time_now = int(round(1541019341*1000))
+    time_now = 1541019341*1000
     record_processed = 0
     df = [ ]
 
     while record_processed < total_record:
         deviceID = np.random.randint(1, 3)
-	sensorID = np.random.randint(1, 50)
+        sensorID = np.random.randint(1, 50)
         env_temp = np.random.normal(24.5, 2)  # ambient temp 
-        time = long(time_now + np.random.randint(10,1500))
-        time_now = time
+        time_now += np.random.randint(10,1500)
         power = np.random.normal(10, 3) # power consumption
         noise = np.random.normal(0,1.5)
         temp = 1.3 * env_temp + 0.5 * power + 5 + noise
 
-        df.append(dict(device=int(deviceID), sensor=int(sensorID), ts=time, env_temp=float(env_temp), power=float(power), temperature=float(temp)))
+        df.append(dict(device=int(deviceID), sensor=int(sensorID), ts=time_now, env_temp=float(env_temp), power=float(power), temperature=float(temp)))
         record_processed += 1
 
     df = pd.DataFrame(df)


### PR DESCRIPTION
Output of the CSV should not be affected, but can now run it with py2 or py3.

Fixes:
* Replace one TAB with spaces
* Don't use long() (because py3)
* Simplify some of the rounding and assigning of ints
* Fix the usage comment to correctly say 1000000