### PR TITLE
remote db2 client example

### DIFF
--- a/db2client_remote/README.md
+++ b/db2client_remote/README.md
@@ -1,0 +1,112 @@
+# Setting up a remote connection from a standard Db2 client to a Db2 Event Store database 
+
+This document provides an example for setting up a remote Db2 client to connect to a Db2 Event Store database, and from this client be able to create and drop tables, load CSV files, and query the database.
+
+This example is built using a container that already contains the latest Db2 10.5, and that can be downloaded directly from docker hub [ibmcom/db2](https://hub.docker.com/r/ibmcom/db2). This same example can be modified to run it on any local installation of a Db2 server or Db2 client.
+
+The example has two parts:
+
+1. A setup script to configure the Db2 client to connect to a Db2 Event Store instance and database.
+
+In the following example, we invoke the script providing an external directory to store any persistent data outside the client container, the acceptance of the licence for the Db2 client container, and the IP address to the cluster and credentials for the test connection:
+
+```
+./setup_container_db2client_to_eventstore.sh  --shared-path /home/cmgarcia/db2client_external/shared_path/  --licence accept --eventstore-cluster-ip 172.16.173.163 --eventstore-cluster-db2-ip 172.16.173.163 --eventstore-user admin --eventstore-password password
+```
+
+2. A script with a sample SQL code to load data from a CSV file and then query this data using the configured Db2 client from step 1.
+
+In the following example we invoke the test script with the credentials to establish the connection to the database and the sample CSV file generated that will be loaded into the Db2 Event Store database:
+
+```
+$ ./remote_load_csv_using_db2client_container.sh --eventstore-user admin --eventstore-password password --csv-file sample_IOT_table.csv
+```
+
+Once the two parts are completed you can access the container using the instance owner name, establish a new connection to the database and from there execute other Db2 client commands against the remote DB2 Event Store database.
+
+```
+$ docker ps 
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                           NAMES
+4facc111479a        ibmcom/db2          "/var/db2_setup/lib/…"   2 hours ago         Up 2 hours          22/tcp, 50000/tcp, 55000/tcp, 60006-60007/tcp   db2-user1
+$ docker exec -it  db2 bash -c "su - db2inst1"
+```
+
+## Setting up the Db2 client Connection to a Db2 Event Store instance and database
+
+In this section we will describe the steps followed within the setup script to configure the remote connection from the Db2 client to the remote Db2 Event Store database.
+
+First, start the container with the Db2 client like the following:
+
+```
+$ docker run -itd --name db2 -e DBNAME=testdb -v ~/:/database -e DB2INST1_PASSWORD=GD1OJfLGG64HV2dtwK -e LICENSE=accept -p 50000:50000 --privileged=true ibmcom/db2
+```
+
+Then enter the container:
+
+```
+$ docker exec -it  db2 bash -c "su - db2inst1"
+```
+
+For the next steps follow the documentation for [Configuring Secure Sockets Layer (SSL) support in non-Java Db2 clients](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.admin.sec.doc/doc/t0053518.html)
+
+First, use the GSKCapiCmd tool to create a key database on the client by using GSKit ```gsk8capicmd_64```. For example, within the client container do the following:
+
+```
+[db2inst1@a33d5b29ffa2 ~]$ gsk8capicmd_64 -keydb -create -db "mydbclient.kdb" -pw "myClientPassw0rdpw0" -stash
+```
+Second, copy the default self-signed certificate from the Db2 Event Store cluster. 
+
+For example, access the Db2 Event Store cluster, and then within the cluster run the following to determine one of the engine PODS followed by a copy of the certificatre file from the POD:
+
+```
+# kubectl get pods -n dsx | grep eventstore-tenant-engine | head -1
+eventstore-tenant-engine-565d74cfd8-64jv4         1/1       Running     0          21h
+
+# kubectl exec -n dsx eventstore-tenant-engine-565d74cfd8-64jv4 -- cat /eventstorefs/eventstore/db2inst1/sqllib_shared/gskit/certs/eventstore_ascii.cert
+```
+
+With this, create a server-certificate.cert file on the client (that is, in this example, within the client container), and then add the certificate to the client key database. 
+
+Following the example, run the following command within the client container to add the certificate to the previously created key database:
+
+```
+[db2inst1@a33d5b29ffa2 ~]$ gsk8capicmd_64 -cert -add -db "mydbclient.kdb" -pw "myClientPassw0rdpw0"  -label "server" -file "server-certificate.cert" -format ascii -fips
+```
+
+And finally update the configuration on the client to use the key database you just set up:
+
+```
+[db2inst1@a33d5b29ffa2 ~]$ db2 update dbm cfg using
+      SSL_CLNT_KEYDB /home/test1/sqllib/security/keystore/clientkey.kdb
+      SSL_CLNT_STASH /home/test1/sqllib/security/keystore/clientstore.sth
+```
+Then, follow the documentation to [catalog a remote TCPIP node using SECURITY SSL](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.admin.cmd.doc/doc/r0001944.html):
+
+```
+[db2inst1@a33d5b29ffa2 ~]$ db2 catalog tcpip node nova remote 172.16.197.11 server 18730 SECURITY SSL
+DB20000I  The CATALOG TCPIP NODE command completed successfully.
+DB21056W  Directory changes may not be effective until the directory cache is
+refreshed.
+```
+
+And lastly, follow the documentation to [catalog the database using AUTHENTICATION GSSPLUGIN](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.admin.cmd.doc/doc/r0001936.html):
+
+```
+[db2inst1@a33d5b29ffa2 ~]$ db2 CATALOG DATABASE eventdb AT NODE  nova AUTHENTICATION GSSPLUGIN
+DB20000I  The CATALOG DATABASE command completed successfully.
+DB21056W  Directory changes may not be effective until the directory cache is
+refreshed.
+```
+
+All the set up is done at this point. Now [establish a connection](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0000908.html?pos=2) to the remote Db2 Event Store database using the user and the password to validate this configuration:
+
+```
+[db2inst1@a33d5b29ffa2 ~]$ db2 CONNECT TO eventdb USER admin USING password
+
+   Database Connection Information
+
+ Database server        = DB2/LINUXX8664 11.1.9.0
+ SQL authorization ID   = ADMIN
+ Local database alias   = EVENTDB
+```
+

--- a/db2client_remote/remote_load_csv_using_db2client_container.sh
+++ b/db2client_remote/remote_load_csv_using_db2client_container.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+DOCKER_CLIENT_CONTAINER_NAME=db2-${USER}
+
+# default values
+EVENTSTORE_USER=$USER
+EVENTSTORE_PASSWORD=password
+EVENTSTORE_DATABASE=eventdb
+CSV_FILE=sample_IOT_table.csv
+
+function usage()
+{
+cat <<-USAGE #| fmt
+Usage: $0 [OPTIONS] [arg]
+OPTIONS:
+=======
+  --docker-container-name       Docker container name (default db2-${USER})
+  --eventstore-user             Event store user (default: ${USER})
+  --eventstore-password         Event store password (default: password)
+  --csv-file                    Sample CSV file to use during load
+  --help                        Usage
+USAGE
+
+}
+
+while [ -n "$1" ]
+do
+   case $1 in
+      --docker-container-name)
+         DOCKER_CLIENT_CONTAINER_NAME=$2
+         shift 2
+         ;;
+      --eventstore-user)
+         EVENTSTORE_USER=$2
+         shift 2
+         ;;
+      --eventstore-password)
+         EVENTSTORE_PASSWORD=$2
+         shift 2
+         ;;
+      --csv-file)
+         CSV_FILE=$2
+         shift 2
+         ;;
+      --help)
+         usage
+         exit 0
+         ;;
+      --*)
+         echo "Unknown option: $1" >&2
+         usage >&2
+         exit 1
+         ;;
+      *)
+         break;
+         ;;
+   esac
+done
+
+function check_errors() {
+   local RES=$1
+   local MSG=$2
+   if [ $RES -ne 0 ]
+   then
+      echo "Error $RES: running $MSG" >&2
+      exit 1
+   fi
+}
+
+function docker_run_as_instance_owner() 
+{
+   DB2_DEFAULT_USERNAME=db2inst1
+   COMMAND="$@"
+   docker exec ${DOCKER_CLIENT_CONTAINER_NAME} bash -c "su - ${DB2_DEFAULT_USERNAME} -c \"$COMMAND\" "
+}
+
+function docker_run_as_root() 
+{
+   COMMAND="$@"
+   docker exec ${DOCKER_CLIENT_CONTAINER_NAME} bash -c "$COMMAND"
+}
+
+function docker_cp_tgt_container() 
+{
+   FILE_SRC=$1
+   FILE_TGT=$2
+   docker cp ${FILE_SRC} ${DOCKER_CLIENT_CONTAINER_NAME}:${FILE_TGT}
+}
+
+if [ -z "${CSV_FILE}" ]
+then
+   echo "Error: CSV file must be provided" >&2
+   exit 1
+fi
+if [ ! -r "${CSV_FILE}" ]
+then
+   echo "Error: readable CSV file must be provided - ${CSV_FILE}" >&2
+   exit 1
+fi
+
+echo -e "\n\n* Generating a sample SQL file load_csv.sql with db2 commands to create the table, load it and do some simple queries\n"
+cat >load_csv.sql <<EOF
+CONNECT TO ${EVENTSTORE_DATABASE} USER ${EVENTSTORE_USER} USING ${EVENTSTORE_PASSWORD}
+SET CURRENT ISOLATION UR
+CREATE TABLE db2cli_csvload (DEVICEID INTEGER NOT NULL, SENSORID INTEGER NOT NULL, TS BIGINT NOT NULL, AMBIENT_TEMP DOUBLE NOT NULL, POWER DOUBLE NOT NULL, TEMPERATURE DOUBLE NOT NULL, CONSTRAINT "TEST1INDEX" PRIMARY KEY(DEVICEID, SENSORID, TS) INCLUDE (TEMPERATURE)) DISTRIBUTE BY HASH (DEVICEID, SENSORID) ORGANIZE BY COLUMN STORED AS PARQUET
+INSERT INTO db2cli_csvload SELECT * FROM EXTERNAL '/database/${CSV_FILE}' LIKE db2cli_csvload USING (delimiter ',' MAXERRORS 10 SOCKETBUFSIZE 30000 REMOTESOURCE 'YES' LOGDIR '/database/logs' )
+SELECT * FROM db2cli_csvload LIMIT 10
+SELECT COUNT(*) FROM db2cli_csvload 
+SELECT AMBIENT_TEMP FROM db2cli_csvload WHERE TS > 1541019365252 AND TS < 1541019500380 
+DROP TABLE db2cli_csvload
+CONNECT RESET
+TERMINATE
+EOF
+cat load_csv.sql
+
+echo -e "\n\n* Copying load_csv.clp into db2 client container"
+docker_cp_tgt_container load_csv.sql /database/load_csv.sql
+check_errors $? "docker cp load_csv.sql"
+
+echo -e "\n\n* Copying CSV file into db2 client container"
+docker_cp_tgt_container ${CSV_FILE} /database/${CSV_FILE}
+check_errors $? "docker cp ${CSV_FILE}"
+
+echo -e "\n\n* Running sample CLP with create table and remote load\n"
+# Create the logs directory to be world writable as load runs 
+# as the instance owner
+docker_run_as_root mkdir -p /database/logs
+check_errors $? "creating directory /database/logs"
+docker_run_as_root chmod 777 /database/logs
+check_errors $? "changing /database/logs directory permissions"
+docker_run_as_instance_owner db2 -vf /database/load_csv.sql
+check_errors $? "db2 -vf load_csv.sql"
+
+echo -e "\n\n* Load test completed\n"

--- a/db2client_remote/setup_container_db2client_to_eventstore.sh
+++ b/db2client_remote/setup_container_db2client_to_eventstore.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+DB_DIRECTORY=${HOME}/db_directory
+DB2INST1_PASSWORD=GD1OJfLGG64HV2dtwK
+DB2_PORT=$((50000+${UID}))
+LICENCE_ACCEPT=
+SSL_KEY_DATABASE_PASSWORD=myClientPassw0rdpw0
+DOCKER_CLIENT_CONTAINER_NAME=db2-${USER}
+CLUSTER_IP_FOR_SSH=
+CLUSTER_IP_FOR_DB2=
+
+# default values
+DB2_CLIENT_PORT_ON_EVENTSTORE_SERVER=18730
+EVENTSTORE_USER=${USER}
+EVENTSTORE_PASSWORD=password
+EVENTSTORE_NAMESPACE=dsx
+EVENTSTORE_DATABASE=eventdb
+NODE_NAME=nova
+
+function usage()
+{
+cat <<-USAGE #| fmt
+Usage: $0 [OPTIONS] [arg]
+OPTIONS:
+=======
+  --shared-path                 Local path to share with the docker container (default ${HOME}/db_directory)
+  --docker-db2-port             Port to use in docker container for db2 (default: ${DB2_PORT})
+  --docker-container-name       Docker container name (default db2-${USER})
+  --licence                     Licence acceptance: accept/reject
+  --docker-ssl-keydb-password   Password to SSL key database in container (optional)
+  --eventstore-cluster-ip       Event store cluster IP to use for ssh
+  --eventstore-cluster-db2-ip   Event store cluster IP to use for remote db2 client
+  --eventstore-cluster-db2-port Event store cluster port to use for remote db2 client (default 18730)
+  --eventstore-user             Event store user (default: ${USER})
+  --eventstore-password         Event store password (default: password)
+  --eventstore-namespace        Kubernetes namespace in event store cluster (default: dsx)
+  --help                        Usage
+USAGE
+
+}
+
+while [ -n "$1" ]
+do
+   case $1 in
+      --shared-path)
+         DB_DIRECTORY=$2
+         shift 2
+         ;;
+      --docker-db2-port)
+         DB2_PORT=$2
+         shift 2
+         ;;
+      --docker-ssl-keydb-password)
+         SSL_KEY_DATABASE_PASSWORD=$2
+         shift 2
+         ;;
+      --docker-container-name)
+         DOCKER_CLIENT_CONTAINER_NAME=$2
+         shift 2
+         ;;
+      --licence)
+         LICENCE_ACCEPT=$2
+         shift 2
+         ;;
+      --eventstore-cluster-ip)
+         CLUSTER_IP_FOR_SSH=$2
+         shift 2
+         ;;
+      --eventstore-cluster-db2-ip)
+         CLUSTER_IP_FOR_DB2=$2
+         ping -c 1 -q ${CLUSTER_IP_FOR_DB2}  >/dev/null
+         if [ $? -ne 0 ]
+         then
+            echo "Unable to ping ${ CLUSTER_IP_FOR_DB2}" >&2
+            exit 1
+         fi
+         shift 2
+         ;;
+      --eventstore-cluster-db2-port)
+         DB2_CLIENT_PORT_ON_EVENTSTORE_SERVER=$2
+         shift 2
+         ;;
+      --eventstore-user)
+         EVENTSTORE_USER=$2
+         shift 2
+         ;;
+      --eventstore-password)
+         EVENTSTORE_PASSWORD=$2
+         shift 2
+         ;;
+      --eventstore-namespace)
+         EVENTSTORE_NAMESPACE=$2
+         shift 2
+         ;;
+      --help)
+         usage
+         exit 0
+         ;;
+      --*)
+         echo "Unknown option: $1" >&2
+         usage >&2
+         exit 1
+         ;;
+      *)
+         break;
+         ;;
+   esac
+done
+
+if [ "${LICENCE_ACCEPT}" != "accept" ]
+then
+   echo "Unable to proceed. Licence not accepted" >&2
+   usage >&2
+   exit 1
+fi
+
+if [ -z "${CLUSTER_IP_FOR_SSH}" ]
+then
+   echo "Unable to proceed without a cluster IP for SSH into the cluster" >&2
+   usage >&2
+   exit 1
+fi
+
+if [ -z "${CLUSTER_IP_FOR_DB2}" ]
+then
+   echo "Unable to proceed without a cluster IP for DB2" >&2
+   usage >&2
+   exit 1
+fi
+
+function check_errors() {
+   local RES=$1
+   local MSG=$2
+   if [ $RES -ne 0 ]
+   then
+      echo "Error $RES: running $MSG" >&2
+      docker stop ${DOCKER_CLIENT_CONTAINER_NAME}
+      docker rm ${DOCKER_CLIENT_CONTAINER_NAME}
+      exit 1
+   fi
+}
+
+SSH_OPTIONS="-o StrictHostKeyChecking=no"
+RUN_IN_CLUSTER="ssh ${SSH_OPTIONS} root@${CLUSTER_IP_FOR_SSH}"
+
+echo -e "\n\n*Starting db2 client container\n"
+DOCKER_IMAGE=ibmcom/db2
+# DOCKER_IMAGE=registry.ng.bluemix.net/db2team/db2client:new
+# DOCKER_IMAGE=registry.ng.bluemix.net/db2team/db2client:latest
+# PORT_OPTION=-p ${DB2_PORT}:50000
+docker run -itd --name ${DOCKER_CLIENT_CONTAINER_NAME} -v ${DB_DIRECTORY}:/database -e DB2INST1_PASSWORD=${DB2INST1_PASSWORD} -e LICENSE=${LICENCE_ACCEPT} ${PORT_OPTION} --privileged=true ${DOCKER_IMAGE}
+check_errors $? "running the docker container"
+
+echo -e "\n\n* Client container started"
+docker ps | grep ${DOCKER_CLIENT_CONTAINER_NAME}
+
+echo -e "\n\n* Waiting for client container setup to be complete...\n"
+SETUP_COMPLETED_STRING="Setup has completed"
+docker logs ${DOCKER_CLIENT_CONTAINER_NAME} | grep -q "${SETUP_COMPLETED_STRING}"
+RES=$?
+ITER=0
+MAX_ITER=300
+while [ $RES -ne 0 ]
+do
+   if [ $ITER -eq $MAX_ITER ]
+   then
+      echo "Timeout waiting for docker container setup to be completed" >&2
+      exit 1
+   fi 
+   sleep 1
+   docker logs ${DOCKER_CLIENT_CONTAINER_NAME} | grep -q "${SETUP_COMPLETED_STRING}"
+   RES=$?
+   ITER=$(( $ITER + 1 ))
+done
+
+function docker_run() 
+{
+   DB2_DEFAULT_USERNAME=db2inst1
+   COMMAND="$@"
+   docker exec ${DOCKER_CLIENT_CONTAINER_NAME} bash -c "su - ${DB2_DEFAULT_USERNAME} -c \"$COMMAND\" "
+}
+
+function docker_cp_tgt_container() 
+{
+   FILE_SRC=$1
+   FILE_TGT=$2
+   docker cp ${FILE_SRC} ${DOCKER_CLIENT_CONTAINER_NAME}:${FILE_TGT}
+}
+
+echo -e "\n\n* Configuring connection to Event Store database...\n"
+docker_run rm -f /database/config/db2inst1/mydbclient.kdb /database/config/db2inst1/mydbclient.sth /database/config/db2inst1/mydbclient.rdb /database/config/db2inst1/mydbclient.crl 
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ gsk8capicmd_64 -keydb -create -db mydbclient.kdb -pw ************ -stash"
+docker_run gsk8capicmd_64 -keydb -create -db mydbclient.kdb -pw ${SSL_KEY_DATABASE_PASSWORD} -stash
+check_errors $? "gsk8capicmd_64 -keydb -create -db "mydbclient.kdb" -pw ************* -stash"
+
+ENGINE_POD=`${RUN_IN_CLUSTER} kubectl get pods -n ${EVENTSTORE_NAMESPACE} --field-selector=status.phase=Running | grep eventstore-tenant-engine | cut -f1 -d" " | head -1`
+check_errors $? "Attempting to find engine container within the cluster with the provided IP ${CLUSTER_IP_FOR_SSH}"
+if [ -z "${ENGINE_POD}" ]
+then
+   echo "Unable to find Event Store engine POD within the cluster with the provided IP ${CLUSTER_IP_FOR_SSH}" >&2
+   exit 1
+fi
+
+echo -e "\n\n   - Retrieving SSL certificate from Event Store cluster and copying into the db2 client container\n"
+${RUN_IN_CLUSTER} kubectl exec -n ${EVENTSTORE_NAMESPACE} ${ENGINE_POD} -- cat /eventstorefs/eventstore/db2inst1/sqllib_shared/gskit/certs/eventstore_ascii.cert >server-certificate.cert
+check_errors $? "Attempting to retrieve SSL certificate"
+
+docker_cp_tgt_container server-certificate.cert /database/config/db2inst1/server-certificate.cert
+check_errors $? "storing SSL certifiate within the docker container"
+rm server-certificate.cert
+
+echo -e "\n\n   - Configuring SSL connection to Event Store cluster\n"
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ gsk8capicmd_64 -cert -add -db mydbclient.kdb -pw ************  -label server -file /database/config/db2inst1/server-certificate.cert -format ascii -fips"
+docker_run gsk8capicmd_64 -cert -add -db mydbclient.kdb -pw ${SSL_KEY_DATABASE_PASSWORD}  -label server -file /database/config/db2inst1/server-certificate.cert -format ascii -fips
+check_errors $? "gsk8capicmd_64 -cert -add -db "mydbclient.kdb" -pw ************* -label "server" -file "server-certificate.cert" -format ascii -fips"
+
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ db2 update dbm cfg using SSL_CLNT_KEYDB /database/config/db2inst1/mydbclient.kdb SSL_CLNT_STASH /database/config/db2inst1/mydbclient.sth"
+docker_run db2 update dbm cfg using SSL_CLNT_KEYDB /database/config/db2inst1/mydbclient.kdb SSL_CLNT_STASH /database/config/db2inst1/mydbclient.sth
+check_errors $? "db2 update dbm cfg using SSL_CLNT_KEYDB /database/config/db2inst1/mydbclient.kdb SSL_CLNT_STASH /database/config/db2inst1/mydbclient.sth"
+
+echo -e "\n\n   - Configuring connection to Event Store cluster node\n"
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ db2 UNCATALOG NODE ${NODE_NAME}"
+docker_run db2 UNCATALOG NODE ${NODE_NAME}
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ db2 CATALOG TCPIP NODE ${NODE_NAME} REMOTE ${CLUSTER_IP_FOR_DB2} SERVER ${DB2_CLIENT_PORT_ON_EVENTSTORE_SERVER} SECURITY SSL"
+docker_run db2 CATALOG TCPIP NODE ${NODE_NAME} REMOTE ${CLUSTER_IP_FOR_DB2} SERVER ${DB2_CLIENT_PORT_ON_EVENTSTORE_SERVER} SECURITY SSL
+check_errors $? "db2 CATALOG TCPIP NODE ${NODE_NAME} REMOTE ${CLUSTER_IP_FOR_DB2} SERVER ${DB2_CLIENT_PORT_ON_EVENTSTORE_SERVER} SECURITY SSL"
+
+echo -e "\n\n   - Adding Event Store database to catalog\n"
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ db2 UNCATALOG DATABASE ${EVENTSTORE_DATABASE}"
+docker_run db2 UNCATALOG DATABASE ${EVENTSTORE_DATABASE}
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ db2 CATALOG DATABASE ${EVENTSTORE_DATABASE} AT NODE ${NODE_NAME} AUTHENTICATION GSSPLUGIN"
+docker_run db2 CATALOG DATABASE ${EVENTSTORE_DATABASE} AT NODE ${NODE_NAME} AUTHENTICATION GSSPLUGIN
+check_errors $? "db2 CATALOG DATABASE ${EVENTSTORE_DATABASE} AT NODE ${NODE_NAME} AUTHENTICATION GSSPLUGIN"
+
+echo -e "\n\n   - Testing connection to Event Store database\n"
+echo -e "\n\n[${DOCKER_CLIENT_CONTAINER_NAME}] $ db2 CONNECT TO ${EVENTSTORE_DATABASE} USER ${EVENTSTORE_USER} USING ************"
+docker_run db2 CONNECT TO ${EVENTSTORE_DATABASE} USER ${EVENTSTORE_USER} USING ${EVENTSTORE_PASSWORD}
+check_errors $? "db2 CONNECT TO ${EVENTSTORE_DATABASE} USER ${EVENTSTORE_USER} USING ************"
+
+echo -e "\n\n* Connection to event store database is configured\n"


### PR DESCRIPTION
This adds a sub-directory with a remote db2 client example using the Db2 container on dockerhub. For more details, refer to the README.md under the db2client_remote folder.