### PR TITLE
Support multiple deployment types in our application container

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -2,21 +2,38 @@
 
 The Dockerfile in this directory will build a docker image named `eventstore_demo`. The image contains remote applications and runtime environment for Event Store demo. Users can build the docker image, run the docker container from the image built, and run the pre-loaded examples in the docker container.
 
-**Procedure:**  
-**Step 1: Build the docker image**  
-User need to run the shell script `build.sh` to build the docker image.  
+**Procedure:**
+**Step 1: Build the docker image**
+User need to run the shell script `build.sh` to build the docker image.
 The image size is around 3.3 GB, build takes around 30 mins, depending on the network condition.
 ```
 ./build.sh
 ```
 
-**Step 2: Start the docker container**  
-After the image is built, user can run the shell script `dockershell.sh` to start the container and run the examples.  
-The script takes 3 mandatory arguments.  
+**Step 2: Start the docker container**
+After the image is built, user can run the shell script `dockershell.sh` to start the container and run the examples.
+The script takes 3 mandatory arguments and 3 optional ones.
 
-`./dockershell.sh --IP <EventStore_Server_IP> --user <EventStore_Username> --password <EventStore_Password>`
+`./dockershell.sh --IP <EventStore_Server_IP> --IPREST <EventStore_Rest_Endpoint> --user <EventStore_Username> --password <EventStore_Password> --deploymentType <deployment type> --serviceName <service name>`
+
+How to run with different deployment types:
+
+IBM Cloud Pak For Data (cp4d) // Default deployment type
+- Generally this requires you to specify --IPREST as the rest endpoint differs from the eventstore server ip (i.e. --IP)
+- This requires the --serviceName which is specific to the database and can be retrieved from the UI
+- This requires the user and password options
+
+Watson Studio Local (dsx)
+- Generally the eventstore server ip and the rest endpoint are the same, implying you only need to specify --IP
+- This requires the user and password options
+
+Standalone container (standalone)
+- This requires the --IP of the container where the eventstore server is running, there is no REST server here so --IPREST is not applicable
+- This requires the user and password options
+
+See the scripts help option for more details (i.e. `./dockershell.sh --help`)
 
 After the above commnand:
 - A docker container instance named `eventstore_demo_${user}` will be started. The container instance contains necessary run-time environments for running applications in Python, Java, JDBC, Scala, Kafka, REST (Node.js), and Spark.
-- The docker container instance will create the configuration file at `/bluspark/external_conf/bluspark.conf` based on the Event Store server IP provided as argument to dockershell.sh. The configuration file contains the necessary configurations to establish SSL connection.
+- The environment will be setup with the necessary configurations to establish SSL connection with the SDKs where applicable (i.e. when not using a standalone deployment, which does not use SSL).
 - Mount hostpath `${HOME}/eventstore_demo_volume` to `/root/user_volume` inside the container.

--- a/container/README.md
+++ b/container/README.md
@@ -14,26 +14,26 @@ The image size is around 3.3 GB, build takes around 30 mins, depending on the ne
 After the image is built, user can run the shell script `dockershell.sh` to start the container and run the examples.
 The script takes 3 mandatory arguments and 3 optional ones.
 
-`./dockershell.sh --IP <EventStore_Server_IP> --IPREST <EventStore_Rest_Endpoint> --user <EventStore_Username> --password <EventStore_Password> --deploymentType <deployment type> --serviceName <service name>`
+`./dockershell.sh --endpoint <EventStore_Server_Endpoint> --endpointRest <EventStore_Rest_Endpoint> --user <EventStore_Username> --password <EventStore_Password> --deploymentType <deployment type> --deploymentID <deployment ID>`
 
 How to run with different deployment types:
 
 IBM Cloud Pak For Data (cp4d) // Default deployment type
-- Generally this requires you to specify --IPREST as the rest endpoint differs from the eventstore server ip (i.e. --IP)
-- This requires the --serviceName which is specific to the database and can be retrieved from the UI
+- Generally this requires you to specify --endpointRest as the rest endpoint differs from the eventstore server endpoint (i.e. --endpoint)
+- This requires the --deploymentID which is specific to the database and can be retrieved from the UI
 - This requires the user and password options
 
-Watson Studio Local (dsx)
-- Generally the eventstore server ip and the rest endpoint are the same, implying you only need to specify --IP
+Watson Studio Local (wsl)
+- Generally the eventstore server endpoint and the rest endpoint are the same, implying you only need to specify --endpoint
 - This requires the user and password options
 
-Standalone container (standalone)
-- This requires the --IP of the container where the eventstore server is running, there is no REST server here so --IPREST is not applicable
+Developer container (developer)
+- This requires the --endpoint of the container where the eventstore server is running, there is no REST server here so --endpointRest is not applicable
 - This requires the user and password options
 
 See the scripts help option for more details (i.e. `./dockershell.sh --help`)
 
 After the above commnand:
 - A docker container instance named `eventstore_demo_${user}` will be started. The container instance contains necessary run-time environments for running applications in Python, Java, JDBC, Scala, Kafka, REST (Node.js), and Spark.
-- The environment will be setup with the necessary configurations to establish SSL connection with the SDKs where applicable (i.e. when not using a standalone deployment, which does not use SSL).
+- The environment will be setup with the necessary configurations to establish SSL connection with the SDKs where applicable (i.e. when not using a developer deployment, which does not use SSL).
 - Mount hostpath `${HOME}/eventstore_demo_volume` to `/root/user_volume` inside the container.

--- a/container/dockershell.sh
+++ b/container/dockershell.sh
@@ -6,8 +6,8 @@ USER_VOLUME=${HOME}/eventstore_demo_volume
 
 # Deployment type constants, default to cp4d
 declare -r deployTypeCp4d="cp4d"
-declare -r deployTypeDsx="dsx"
-declare -r deployTypeStandalone="standalone"
+declare -r deployTypeWsl="wsl"
+declare -r deployTypeDeveloper="developer"
 declare -r defaultDeployType=$deployTypeCp4d
 
 if [ -f ${HOME}/.user_info ]; then
@@ -23,7 +23,7 @@ cat <<-USAGE #| fmt
 
 Description:
 This script is the entrypoint of the eventstore_demo container. The script takes
-target Event Store server's public IP, optionally the target Event Store server's REST
+target Event Store server's public IP or dns name, optionally the target Event Store server's REST
 endpoint (required if it differs from the public IP), optionally the target Event Store
 server's deployment type, and the deployment's user and password.
 
@@ -33,22 +33,22 @@ image: eventstore_demo:latest.
 Usage: $0 [OPTIONS] [arg]
 OPTIONS:
 ========
---IP        Public IP address or DNS name of the target Event Store server
---IPR       The REST endpoint IP or DNS name of the Event Store server.
-            This is to be used when the REST endpoint differs from the Public IP
-            (i.e. --IP) ... typically the case for cp4d deployments
+--endpoint     Public endpoint address or DNS name of the target Event Store server used by the SDKs to connect to the database
+--endpointRest The REST endpoint IP or DNS name of the Event Store server.
+               This is to be used when the REST endpoint differs from the Public IP
+               (i.e. --endpoint) ... typically the case for cp4d deployments
 --deploymentType
-            The deployment type of the Event Store server, valid options include (default is cp4d):
-               cp4d (Cloud Pak for Data deployments)
-               dsx (DSX/WSL deployments)
-               standalone (standalone/desktop container deployments)
---serviceName
-            cp4d deployments utilize a per database service name that must be specified.
-            This can be found in the database details page on the IBM Cloud Pak for Data UI console.
-            This field is only required for cp4d deployment types.
-               e.g. "db2eventstore-1578174815082"
---user      User name of the Event Store server
---password  Password of the Event Store server
+               The deployment type of the Event Store server, valid options include (default is cp4d):
+                  cp4d (Cloud Pak for Data deployments)
+                  wsl (WSL deployments)
+                  developer (developer container deployments)
+--deploymentID
+               cp4d deployments utilize a per database deployment ID that must be specified.
+               This can be found in the database details page on the IBM Cloud Pak for Data UI console.
+               This field is only required for cp4d deployment types.
+                  e.g. "db2eventstore-1578174815082"
+--user         User name of the Event Store server
+--password     Password of the Event Store server
 -----------
 USAGE
 }
@@ -59,20 +59,20 @@ while [ -n "$1" ]; do
         usage >&2
         exit 0
         ;;
-    --IP)
-        IP="$2"
+    --endpoint)
+        ENDPOINT="$2"
         shift 2
         ;;
-    --IPR)
-        IPREST="$2"
+    --endpointRest)
+        ENDPOINT_REST="$2"
         shift 2
         ;;
     --deploymentType)
-        DTYPE="$2"
+        DEPLOYMENT_TYPE="$2"
         shift 2
         ;;
-    --serviceName)
-        SERVICE_NAME="$2"
+    --deploymentID)
+        DEPLOYMENT_ID="$2"
         shift 2
         ;;
     --user)
@@ -84,56 +84,56 @@ while [ -n "$1" ]; do
         shift 2
         ;;
     *)
-        printf "Unknown option:$1"
+        printf "Unknown option: '$1'"
         usage >&2
         exit 1
     esac
 done
 
 if [ -z ${EVENT_USER} ]; then
-    printf "Error: Please provide the cluster user name with --user flag\n"
+    printf "Error: Please provide Db2 Event Store instance user name with --user flag\n" >&2
     usage >&2
     exit 1
 fi
 
 if [ -z ${EVENT_PASSWORD} ]; then
-    printf "Error: Please provide the cluster password with --password flag\n"
+    printf "Error: Please provide Db2 Event Store instance password with --password flag\n" >&2
     usage >&2
     exit 1
 fi
 
-if [ -z ${IP} ]; then
-    printf "Error: Please provide the Event Store server's public IP with --IP flag\n"
+if [ -z ${ENDPOINT} ]; then
+    printf "Error: Please provide the Event Store server's public endpoint with --endpoint flag\n" >&2
     usage >&2
     exit 1
 fi
 
-if [ -z ${DTYPE} ]; then
+if [ -z ${DEPLOYMENT_TYPE} ]; then
     printf "DeploymentType (--deploymentType) not specified, defaulting too: $defaultDeployType\n"
-    DTYPE=$defaultDeployType
+    DEPLOYMENT_TYPE=$defaultDeployType
 fi
 
-case "$DTYPE" in
+case "$DEPLOYMENT_TYPE" in
    $deployTypeCp4d)
-      if [ -z ${SERVICE_NAME} ]; then
-         printf "Error: cp4d deployment types require a service name (i.e. --service_name) as input\n"
+      if [ -z ${DEPLOYMENT_ID} ]; then
+         printf "Error: cp4d deployment types require a deployment ID (i.e. --deploymentID) as input\n" >&2
          usage >&2
          exit 1
       fi
       ;;
-   $deployTypeDsx)
+   $deployTypeWsl)
       ;;
-   $deployTypeStandalone)
+   $deployTypeDeveloper)
       ;;
    *)
-      printf "Deployment type \"$DTYPE\" not supported!\n"
+      printf "Deployment type \"$DEPLOYMENT_TYPE\" not supported!\n" >&2
       usage >&2
       exit 1
 esac
 
-if [ -z ${IPREST} ]; then
-   printf "Rest Deployment IP (--IPR) not specified, using the (--IP) endpoint: $IP\n"
-   IPREST=$IP
+if [ -z ${ENDPOINT_REST} ]; then
+   printf "Rest Deployment (--endpointRest) not specified, using the (--endpoint) endpoint: $ENDPOINT\n"
+   ENDPOINT_REST=$ENDPOINT
 fi
 
 mkdir -p ${USER_VOLUME}
@@ -141,14 +141,14 @@ mkdir -p ${USER_VOLUME}
 
 entryPoint="env && ${SETUP_PATH}/setup-ssl.sh && ${SETUP_PATH}/entrypoint_msg.sh && bash --login"
 
-# For standalone deployment types there SSL is not enabled so do not execute the
+# For developer deployment types there SSL is not enabled so do not execute the
 # corresponding setup.
-if [ $DTYPE = $deployTypeStandalone ]; then
+if [ $DEPLOYMENT_TYPE = $deployTypeDeveloper ]; then
    entryPoint="${SETUP_PATH}/entrypoint_msg.sh && bash --login"
 fi
 
 docker run -it --name eventstore_demo_${EVENT_USER} -v ${USER_VOLUME}:/root/user_volume \
-    -e EVENT_USER=${EVENT_USER} -e EVENT_PASSWORD=${EVENT_PASSWORD} -e IP=${IP} -e IPREST=${IPREST} -e DTYPE=${DTYPE} -e SERVICE_NAME=${SERVICE_NAME}\
+    -e EVENT_USER=${EVENT_USER} -e EVENT_PASSWORD=${EVENT_PASSWORD} -e IP=${ENDPOINT} -e IPREST=${ENDPOINT_REST} -e DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE} -e DEPLOYMENT_ID=${DEPLOYMENT_ID}\
     eventstore_demo:latest bash -c "$entryPoint"
 
 printf "Cleaning up dangling images and/or exited containers"

--- a/container/dockershell.sh
+++ b/container/dockershell.sh
@@ -133,7 +133,7 @@ esac
 
 if [ -z ${IPREST} ]; then
    printf "Rest Deployment IP (--IPR) not specified, using the (--IP) endpoint: $IP\n"
-   IPR=$IP
+   IPREST=$IP
 fi
 
 mkdir -p ${USER_VOLUME}

--- a/container/dockershell.sh
+++ b/container/dockershell.sh
@@ -1,12 +1,18 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # path within container
 SETUP_PATH="/root/db2eventstore-IoT-Analytics/container/setup"
 USER_VOLUME=${HOME}/eventstore_demo_volume
 
+# Deployment type constants, default to cp4d
+declare -r deployTypeCp4d="cp4d"
+declare -r deployTypeDsx="dsx"
+declare -r deployTypeStandalone="standalone"
+declare -r defaultDeployType=$deployTypeCp4d
+
 if [ -f ${HOME}/.user_info ]; then
-    echo "File: '.user-info' found in the current directory."
-    echo "Extracting user information from the file."
+    printf "File: '.user-info' found in the current directory."
+    printf "Extracting user information from the file."
     EVENT_USER=$(grep  "username" ${HOME}/.user_info |awk {'print $2'})
     EVENT_PASSWORD=$(grep  "password" ${HOME}/.user_info |awk {'print $2'})
 fi
@@ -14,19 +20,36 @@ fi
 function usage()
 {
 cat <<-USAGE #| fmt
+
 Description:
 This script is the entrypoint of the eventstore_demo container. The script takes
-target Event Store server's public IP, Watson Studio Local's username, and password.
-The script will start docker container in interactive mode using the 
-image: eventstore_demo:latest.
+target Event Store server's public IP, optionally the target Event Store server's REST
+endpoint (required if it differs from the public IP), optionally the target Event Store
+server's deployment type, and the deployment's user and password.
 
+The script will start docker container in interactive mode using the:
+image: eventstore_demo:latest.
 -----------
 Usage: $0 [OPTIONS] [arg]
 OPTIONS:
 ========
---IP        Public IP address of the target Event Store server.
---user      User name of the Watson Studio Local user
---password  Password of the Watson Studio Local user
+--IP        Public IP address or DNS name of the target Event Store server
+--IPR       The REST endpoint IP or DNS name of the Event Store server.
+            This is to be used when the REST endpoint differs from the Public IP
+            (i.e. --IP) ... typically the case for cp4d deployments
+--deploymentType
+            The deployment type of the Event Store server, valid options include (default is cp4d):
+               cp4d (Cloud Pak for Data deployments)
+               dsx (DSX/WSL deployments)
+               standalone (standalone/desktop container deployments)
+--serviceName
+            cp4d deployments utilize a per database service name that must be specified.
+            This can be found in the database details page on the IBM Cloud Pak for Data UI console.
+            This field is only required for cp4d deployment types.
+               e.g. "db2eventstore-1578174815082"
+--user      User name of the Event Store server
+--password  Password of the Event Store server
+-----------
 USAGE
 }
 
@@ -40,6 +63,18 @@ while [ -n "$1" ]; do
         IP="$2"
         shift 2
         ;;
+    --IPR)
+        IPREST="$2"
+        shift 2
+        ;;
+    --deploymentType)
+        DTYPE="$2"
+        shift 2
+        ;;
+    --serviceName)
+        SERVICE_NAME="$2"
+        shift 2
+        ;;
     --user)
         EVENT_USER="$2"
         shift 2
@@ -49,39 +84,74 @@ while [ -n "$1" ]; do
         shift 2
         ;;
     *)
-        echo "Unknown option:$1"
+        printf "Unknown option:$1"
         usage >&2
         exit 1
     esac
 done
 
 if [ -z ${EVENT_USER} ]; then
-    echo "Error: Please provide the Watson Studio Local user name with --user flag"
+    printf "Error: Please provide the cluster user name with --user flag\n"
     usage >&2
     exit 1
 fi
 
 if [ -z ${EVENT_PASSWORD} ]; then
-    echo "Error: Please provide the Watson Studio Local password with --password flag"
+    printf "Error: Please provide the cluster password with --password flag\n"
     usage >&2
     exit 1
 fi
 
 if [ -z ${IP} ]; then
-    echo "Error: Please provide the Event Store server's public IP with --IP flag"
+    printf "Error: Please provide the Event Store server's public IP with --IP flag\n"
     usage >&2
     exit 1
+fi
+
+if [ -z ${DTYPE} ]; then
+    printf "DeploymentType (--deploymentType) not specified, defaulting too: $defaultDeployType\n"
+    DTYPE=$defaultDeployType
+fi
+
+case "$DTYPE" in
+   $deployTypeCp4d)
+      if [ -z ${SERVICE_NAME} ]; then
+         printf "Error: cp4d deployment types require a service name (i.e. --service_name) as input\n"
+         usage >&2
+         exit 1
+      fi
+      ;;
+   $deployTypeDsx)
+      ;;
+   $deployTypeStandalone)
+      ;;
+   *)
+      printf "Deployment type \"$DTYPE\" not supported!\n"
+      usage >&2
+      exit 1
+esac
+
+if [ -z ${IPREST} ]; then
+   printf "Rest Deployment IP (--IPR) not specified, using the (--IP) endpoint: $IP\n"
+   IPR=$IP
 fi
 
 mkdir -p ${USER_VOLUME}
 # start container in interactive mode
 
-docker run -it --name eventstore_demo_${EVENT_USER} -v ${USER_VOLUME}:/root/user_volume \
-    -e EVENT_USER=${EVENT_USER} -e EVENT_PASSWORD=${EVENT_PASSWORD} -e IP=${IP} \
-    eventstore_demo:latest \
-    bash -c "${SETUP_PATH}/setup-ssl.sh && ${SETUP_PATH}/entrypoint_msg.sh && bash --login"
+entryPoint="env && ${SETUP_PATH}/setup-ssl.sh && ${SETUP_PATH}/entrypoint_msg.sh && bash --login"
 
-echo "Cleaning up dangling images and/or exited containers"
+# For standalone deployment types there SSL is not enabled so do not execute the
+# corresponding setup.
+if [ $DTYPE = $deployTypeStandalone ]; then
+   entryPoint="${SETUP_PATH}/entrypoint_msg.sh && bash --login"
+fi
+
+docker run -it --name eventstore_demo_${EVENT_USER} -v ${USER_VOLUME}:/root/user_volume \
+    -e EVENT_USER=${EVENT_USER} -e EVENT_PASSWORD=${EVENT_PASSWORD} -e IP=${IP} -e IPREST=${IPREST} -e DTYPE=${DTYPE} -e SERVICE_NAME=${SERVICE_NAME}\
+    eventstore_demo:latest bash -c "$entryPoint"
+
+printf "Cleaning up dangling images and/or exited containers"
 docker rmi $(docker images -q -f dangling=true) > /dev/null 2>&1
 docker rm -v $(docker ps -a -q -f status=exited) > /dev/null 2>&1
-echo "Exited container successfully!"
+printf "Exited container successfully!"

--- a/container/setup/setup-spark.sh
+++ b/container/setup/setup-spark.sh
@@ -45,7 +45,7 @@ tar -xzvf ${SPARK_MEDIA}.tar.gz
 mv ${SPARK_MEDIA}/* $SPARK_HOME
 
 wget -q -O scopt_2.11-${SCOPT_211_VERSION}.jar \
-   http://central.maven.org/maven2/com/github/scopt/scopt_2.11/${SCOPT_211_VERSION}/scopt_2.11-${SCOPT_211_VERSION}.jar
+   https://repo1.maven.org/maven2/com/github/scopt/scopt_2.11/${SCOPT_211_VERSION}/scopt_2.11-${SCOPT_211_VERSION}.jar
 mv scopt_2.11-${SCOPT_211_VERSION}.jar $SPARK_HOME/jars
 chown -R 500:500 $SPARK_HOME/jars/scopt_2.11-${SCOPT_211_VERSION}.jar
 

--- a/container/setup/setup-ssl.sh
+++ b/container/setup/setup-ssl.sh
@@ -1,31 +1,32 @@
 #!/bin/bash
+set -x
 
 function usage()
 {
 cat <<-USAGE #| fmt
 Pre-requisite:
 - This script requires the SSL certificate to be the default self-signed certificate
-- This currently only run on Event Store 2.0 installed with Watson Studio Local
-- You have the public IP of the target Event Store 2.0 server
-- You have the username and password of the Watson Studio Local on the Event Store server
+- You have the REST endpoint of the target Event Store 2.0 (or greater) server
+- You have the username and password of the target cluster
+- You have the service name of the target cluster
+-- Note this is only required for cp4d (IBM Cloud Pak for Data) Event Store deployments
 ========
 Description:
-This script will receive the argument of public IP of target Event Store 2.0 server,
-user and password of the Watson Studio Local on the Event Store 2.0 server.
-Then it will retrieve the clientkeystore file and it's password for the SSL connection
-with Event Store 2.0. The /bluspark/external_conf/bluspark.conf file be created
-with above information.
+This script will use the REST endpoint, user, password, and optionally the service name
+of the target Event Store server to retrieve the clientkeystore file and password. Environment variables
+(and the bashrc) will be setup so applications can use the required parameters for SSL connections.
 
 -----------
 Usage: $0 [OPTIONS] [arg]
 OPTIONS:
 ========
---IP  Public IP of target cluster.
---user User name of Watson Studio Local user
---password Password of Watson Studio Local user
+--IP  Rest endpoint of the target cluster
+--user User name of the target cluster
+--password Password of the target cluster
+--serviceName the service name of the target cluster
+   This is only applicable for cp4d (IBM Cloud Pak for Data) Event Store deployments
 USAGE
 }
-
 while [ -n "$1" ]; do
     case "$1" in
     -h|--help)
@@ -33,7 +34,7 @@ while [ -n "$1" ]; do
         exit 0
         ;;
     --IP)
-        IP="$2"
+        IPREST="$2"
         shift 2
         ;;
     --user)
@@ -42,6 +43,10 @@ while [ -n "$1" ]; do
         ;;
     --password)
         EVENT_PASSWORD="$2"
+        shift 2
+        ;;
+    --serviceName)
+        SERVICE_NAME="$2"
         shift 2
         ;;
     *)
@@ -53,40 +58,49 @@ done
 
 # IP, Evnet_User, Event_Password can be read from the environment variable set by `docker run -e`
 
-if [ -z ${IP} ]; then
-   echo "Error: Please pass in the public IP of your cluster using flag --IP" >&2
+if [ -z ${IPREST} ]; then
+   echo "Error: Please pass in the REST endpoint of your cluster using flag --IP" >&2
    usage >&2
    exit 1
 fi
 
 if [ -z ${EVENT_USER} ]; then
-    echo "Error: Please pass in the Watson Studio Local user name using flag --user" >&2
+    echo "Error: Please pass in the user name using flag --user" >&2
     usage >&2
     exit 1
 fi
 
 if [ -z ${EVENT_PASSWORD} ]; then
-    echo "Error: Please pass in the Watson Studio Local's password name using flag --password" >&2
+    echo "Error: Please pass in the password name using flag --password" >&2
     usage >&2
     exit 1
+fi
+
+# Construct the URL path, this will vary if this is a Cp4d or DSX cluster.
+# The presence of the service name indicates this is a Cp4d cluster.
+URLPATH="com/ibm/event/api/v1"
+
+if [ ! -z ${SERVICE_NAME} ]; then
+   URLPATH="icp4data-databases/${SERVICE_NAME}/zen/com/ibm/event/api/v1"
 fi
 
 # target path to store client ssl key
 KEYDB_PATH="/var/lib/eventstore"
 mkdir -p ${KEYDB_PATH}
 # get bearerToken
-bearerToken=`curl --silent -k -X GET https://${IP}/v1/preauth/validateAuth -u ${EVENT_USER}:${EVENT_PASSWORD} | python -c "import sys, json; print(json.load(sys.stdin)['accessToken'])"`
+bearerToken=`curl --silent -k -X GET https://${IPREST}/v1/preauth/validateAuth -u ${EVENT_USER}:${EVENT_PASSWORD} | python -c "import sys, json; print(json.load(sys.stdin)['accessToken'])"`
 [ $? -ne 0 ] && echo "Not able to get bearerToken" && exit 2
 
 # get clientkeystore file
-curl --silent -k -X GET -H "authorization: Bearer $bearerToken" "https://${IP}:443/com/ibm/event/api/v1/oltp/keystore" -o ${KEYDB_PATH}/clientkeystore
+curl --silent -k -X GET -H "authorization: Bearer $bearerToken" "https://${IPREST}:443/${URLPATH}/oltp/keystore" -o ${KEYDB_PATH}/clientkeystore
 [ $? -ne 0 ] && echo "Not able to get clientkeystore file" && exit 3
 
 # get clientkeystore password
-KEYDB_PASSWORD=$(curl --silent -k -i -X GET -H "authorization: Bearer $bearerToken" "https://${IP}:443/com/ibm/event/api/v1/oltp/keystore_password" | tail -1)
+KEYDB_PASSWORD=$(curl --silent -k -i -X GET -H "authorization: Bearer $bearerToken" "https://${IPREST}:443/${URLPATH}/oltp/keystore_password" | tail -1)
 [ $? -ne 0 ] && echo "Not able to get clientkeystore password" && exit 4
+
 # get server certificate
-curl -k -X GET -H "authorization: Bearer $bearerToken" "https://${IP}:443/com/ibm/event/api/v1/oltp/certificate" -o ${KEYDB_PATH}/eventstore.pem
+curl -k -X GET -H "authorization: Bearer $bearerToken" "https://${IPREST}:443/${URLPATH}/oltp/certificate" -o ${KEYDB_PATH}/eventstore.pem
 [ $? -ne 0 ] && echo "Not able to get server certificate" && exit 5
 
 # export the KEYDB_PATH and KEYDB_PASSWORD only if it's in a container.
@@ -99,3 +113,4 @@ if [ -f "/.dockerenv" ]; then
     echo "export SERVER_CERT_PATH=${KEYDB_PATH}/eventstore.pem" >> ~/.bashrc
     source ~/.bashrc
 fi
+

--- a/container/setup/setup-ssl.sh
+++ b/container/setup/setup-ssl.sh
@@ -8,12 +8,12 @@ Pre-requisite:
 - This script requires the SSL certificate to be the default self-signed certificate
 - You have the REST endpoint of the target Event Store 2.0 (or greater) server
 - You have the username and password of the target cluster
-- You have the service name of the target cluster
+- You have the deployment ID of the target cluster
 -- Note this is only required for cp4d (IBM Cloud Pak for Data) Event Store deployments
 ========
 Description:
-This script will use the REST endpoint, user, password, and optionally the service name
-of the target Event Store server to retrieve the clientkeystore file and password. Environment variables
+This script will use the REST endpoint, user, password, and optionally the deployment ID
+of the target Db2 Event Store instance to retrieve the clientkeystore file and password. Environment variables
 (and the bashrc) will be setup so applications can use the required parameters for SSL connections.
 
 -----------
@@ -23,7 +23,7 @@ OPTIONS:
 --IP  Rest endpoint of the target cluster
 --user User name of the target cluster
 --password Password of the target cluster
---serviceName the service name of the target cluster
+--deploymentID the deployment ID name of the target cluster
    This is only applicable for cp4d (IBM Cloud Pak for Data) Event Store deployments
 USAGE
 }
@@ -45,8 +45,8 @@ while [ -n "$1" ]; do
         EVENT_PASSWORD="$2"
         shift 2
         ;;
-    --serviceName)
-        SERVICE_NAME="$2"
+    --deploymentID)
+        DEPLOYMENT_ID="$2"
         shift 2
         ;;
     *)
@@ -77,11 +77,11 @@ if [ -z ${EVENT_PASSWORD} ]; then
 fi
 
 # Construct the URL path, this will vary if this is a Cp4d or DSX cluster.
-# The presence of the service name indicates this is a Cp4d cluster.
+# The presence of the deployment ID indicates this is a Cp4d cluster.
 URLPATH="com/ibm/event/api/v1"
 
-if [ ! -z ${SERVICE_NAME} ]; then
-   URLPATH="icp4data-databases/${SERVICE_NAME}/zen/com/ibm/event/api/v1"
+if [ ! -z ${DEPLOYMENT_ID} ]; then
+   URLPATH="icp4data-databases/${DEPLOYMENT_ID}/zen/com/ibm/event/api/v1"
 fi
 
 # target path to store client ssl key


### PR DESCRIPTION
The existing application container (demo) only supports dsx/wsl based deployments, the following changes update container startup and setup scripts to support:
IBM Cloud Pak for Data (cp4d)
Watson Studio Local (dsx)
Standalone container (standalone) // Please note this is not yet released, but I wanted to add the support to our application container ahead of time.

Most of the changes resolve around new env vars to detect the different deployment types and act appropriately.  cp4d requires a few more arguments as the rest endpoint may differ from the cluster IP and a new service name is required (as it supports multiple databases).