### PR TITLE
Increase connection timeout.

### DIFF
--- a/AdvancedApplications/PythonApplication/ExamplePythonApp.py
+++ b/AdvancedApplications/PythonApplication/ExamplePythonApp.py
@@ -13,7 +13,7 @@ db2port = os.environ['DB2_PORT'];
 esport = os.environ['ES_PORT'];
 print("Connecting to {}".format(ip))
 ConfigurationReader.setConnectionEndpoints("{}:{};{}:{}".format(ip,db2port,ip,esport))
-ConfigurationReader.setConnectionTimeout(2)
+ConfigurationReader.setConnectionTimeout(10)
 
 # set user credential
 ConfigurationReader.setEventUser(os.environ['EVENT_USER']);

--- a/AdvancedApplications/ScalaApplication/ExampleScalaApp.scala
+++ b/AdvancedApplications/ScalaApplication/ExampleScalaApp.scala
@@ -17,7 +17,7 @@ object ExampleScalaApp {
     val esport = sys.env("ES_PORT")
     println(s"Connecting to $ip;")
     ConfigurationReader.setConnectionEndpoints(s"$ip:$db2port;$ip:$esport")
-    ConfigurationReader.setConnectionTimeout(2)
+    ConfigurationReader.setConnectionTimeout(10)
     
     // set user credential
     ConfigurationReader.setEventUser(sys.env("EVENT_USER"))

--- a/AdvancedApplications/ScalaApplication/ExampleScalaAppNoSSL.scala
+++ b/AdvancedApplications/ScalaApplication/ExampleScalaAppNoSSL.scala
@@ -17,7 +17,7 @@ object ExampleScalaAppNoSSL {
     val esport = sys.env("ES_PORT")
     println(s"Connecting to $ip;")
     ConfigurationReader.setConnectionEndpoints(s"$ip:$db2port;$ip:$esport")
-    ConfigurationReader.setConnectionTimeout(2)
+    ConfigurationReader.setConnectionTimeout(10)
     
     // set user credential
     ConfigurationReader.setEventUser(sys.env("EVENT_USER"))


### PR DESCRIPTION
On smaller (i.e. Memory constrained) clusters the current 2 second timeout is not always sufficient.